### PR TITLE
Fix issues #12, #13, #15

### DIFF
--- a/MeowFaceExtTrackingInterface/MeowContainer.cs
+++ b/MeowFaceExtTrackingInterface/MeowContainer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Newtonsoft.Json;
 
 namespace MeowFaceExtTrackingInterface
 {
@@ -16,58 +17,7 @@ namespace MeowFaceExtTrackingInterface
         public MeowVector EyeLeft { get; set; }
         public MeowVector EyeRight { get; set; }
 
-        // the data is jumbled like this. we only need to use this to get the key/value pair from the json sent.
-        public MeowShape[] BlendShapes  { get; set; } =
-        {
-            new MeowShape( "jawOpen", 0.0f ),
-            new MeowShape( "eyeLookOutRight", 0.0f ),
-            new MeowShape( "eyeLookDownRight", 0.0f ),
-            new MeowShape( "noseSneerLeft", 0.0f ),
-            new MeowShape( "eyeLookOutLeft", 0.0f ),
-            new MeowShape( "noseSneerRight", 0.0f ),
-            new MeowShape( "mouthLeft", 0.0f ),
-            new MeowShape( "headRight", 0.0f ),
-            new MeowShape( "eyeLookUpLeft", 0.0f ),
-            new MeowShape( "eyeLookUpRight", 0.0f ),
-            new MeowShape( "headUp", 0.0f ),
-            new MeowShape( "mouthRollLower", 0.0f ),
-            new MeowShape( "cheekPuff", 0.0f ),
-            new MeowShape( "browOuterUpRight", 0.0f ),
-            new MeowShape( "eyeLookInRight", 0.0f ),
-            new MeowShape( "mouthUpperUpLeft", 0.0f ),
-            new MeowShape( "browInnerUpRight", 0.0f ),
-            new MeowShape( "headRollRight", 0.0f ),
-            new MeowShape( "eyeLookInLeft", 0.0f ),
-            new MeowShape( "jawLeft", 0.0f ),
-            new MeowShape( "browInnerUpLeft", 0.0f ),
-            new MeowShape( "mouthUpperUpRight", 0.0f ),
-            new MeowShape( "mouthRight", 0.0f ),
-            new MeowShape( "browDownRight", 0.0f ),
-            new MeowShape( "headDown", 0.0f ),
-            new MeowShape( "eyeWideRight", 0.0f ),
-            new MeowShape( "browDownLeft", 0.0f ),
-            new MeowShape( "mouthShrugUpper", 0.0f ),
-            new MeowShape( "mouthRollUpper", 0.0f ),
-            new MeowShape( "eyeWideLeft", 0.0f ),
-            new MeowShape( "browOuterUoLeft", 0.0f ),
-            new MeowShape( "tongueOut", 0.0f ),
-            new MeowShape( "eyeSquintLeft", 0.0f ),
-            new MeowShape( "jawRight", 0.0f ),
-            new MeowShape( "mouthLowerDownRight", 0.0f ),
-            new MeowShape( "mouthLowerDownLeft", 0.0f ),
-            new MeowShape( "eyeLookDownLeft", 0.0f ),
-            new MeowShape( "eyeSquintRight", 0.0f ),
-            new MeowShape( "mouthFrownLeft", 0.0f ),
-            new MeowShape( "mouthFrownRight", 0.0f ),
-            new MeowShape( "mouthSmileRight", 0.0f ),
-            new MeowShape( "headRollLeft", 0.0f ),
-            new MeowShape( "eyeBlinkLeft", 0.0f ),
-            new MeowShape( "mouthPucker", 0.0f ),
-            new MeowShape( "eyeBlinkRight", 0.0f ),
-            new MeowShape( "mouthSmileLeft", 0.0f ),
-            new MeowShape( "mouthFunnel", 0.0f ),
-            new MeowShape( "headLeft", 0.0f ),
-            new MeowShape( "browInnerUp", 0.0f )
-        };
+        [JsonConverter(typeof(MeowShapeListConverter))]
+        public MeowShape[] BlendShapes { get; set; } = Array.Empty<MeowShape>();
     }
 }

--- a/MeowFaceExtTrackingInterface/MeowDataStructure.cs
+++ b/MeowFaceExtTrackingInterface/MeowDataStructure.cs
@@ -12,18 +12,26 @@ namespace MeowFaceExtTrackingInterface
         public float y { get; set; }
         public float z { get; set; }
     }
-    public struct MeowShape 
-    { 
+    public struct MeowNamedShape
+    {
         public string k { get; set; }
         public float v { get; set; }
 
-        public MeowShape(string key, float value)
+        public MeowNamedShape(string key, float value)
         {
             k = key;
             v = value;
         }
     }
+    public struct MeowShape
+    {
+        public float v { get; set; }
 
+        public MeowShape(float value)
+        {
+            v = value;
+        }
+    }
     public enum MeowShapeType
     {
         jawOpen,

--- a/MeowFaceExtTrackingInterface/MeowFaceExtTrackingInterface.cs
+++ b/MeowFaceExtTrackingInterface/MeowFaceExtTrackingInterface.cs
@@ -1,7 +1,8 @@
 ﻿using System.Net;
 using System.Net.Sockets;
-using System.Text.Json;
+using System.Text;
 using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
 using VRCFaceTracking;
 using VRCFaceTracking.Core.Params.Data;
 using VRCFaceTracking.Core.Params.Expressions;
@@ -54,7 +55,11 @@ namespace MeowFaceExtTrackingInterface
                 try
                 {
                     buffer = client.Receive(ref endPoint);
-                    dataBuffer = JsonSerializer.Deserialize<MeowFaceData>(buffer) ?? dataBuffer;
+                    string json = Encoding.UTF8.GetString(buffer);
+
+                    Logger.LogDebug("Received initial MeowFace JSON data: {}", json);
+
+                    dataBuffer = JsonConvert.DeserializeObject<MeowFaceData>(json) ?? dataBuffer;
                     sendData = (eyeAvailable, expressionAvailable);
                 }
                 catch (SocketException)
@@ -173,7 +178,8 @@ namespace MeowFaceExtTrackingInterface
             try
             {
                 buffer = client.Receive(ref endPoint);
-                dataBuffer = JsonSerializer.Deserialize<MeowFaceData>(buffer) ?? dataBuffer;
+                string json = Encoding.UTF8.GetString(buffer);
+                dataBuffer = JsonConvert.DeserializeObject<MeowFaceData>(json) ?? dataBuffer;
 
                 if (sendData.Item1)
                 {

--- a/MeowFaceExtTrackingInterface/MeowFaceExtTrackingInterface.csproj
+++ b/MeowFaceExtTrackingInterface/MeowFaceExtTrackingInterface.csproj
@@ -17,7 +17,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="7.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MeowFaceExtTrackingInterface/MeowJsonConverter.cs
+++ b/MeowFaceExtTrackingInterface/MeowJsonConverter.cs
@@ -1,0 +1,39 @@
+﻿using Newtonsoft.Json;
+
+namespace MeowFaceExtTrackingInterface
+{
+    public class MeowShapeListConverter : JsonConverter<MeowShape[]>
+    {
+        public override MeowShape[] ReadJson(JsonReader reader, Type objectType, MeowShape[]? existingValue, bool hasExistingValue, JsonSerializer serializer)
+        {
+            // Convert JSON to JArray
+            MeowNamedShape[] namedShapes = serializer.Deserialize<MeowNamedShape[]>(reader) ?? Array.Empty<MeowNamedShape>();
+
+            // Initialize array with the number of enum values
+            MeowShape[] blendShapes = new MeowShape[Enum.GetValues(typeof(MeowShapeType)).Length];
+            Array.Fill(blendShapes, new MeowShape()); // Initialize array values
+
+            foreach (MeowNamedShape namedShape in namedShapes)
+            {
+                // Try to convert the string to an enum
+                if (Enum.TryParse(namedShape.k, true, out MeowShapeType shapeType))
+                {
+                    // Store the value at the enum index position
+                    blendShapes[(int)shapeType].v = namedShape.v;
+                }
+            }
+
+            return blendShapes;
+        }
+
+        public override void WriteJson(JsonWriter writer, MeowShape[]? value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException("Serialization not implemented.");
+        }
+
+        public override bool CanWrite
+        {
+            get { return false; }
+        }
+    }
+}


### PR DESCRIPTION
Fixed wrong mapping of tracking values from some android devices using a new JSON converter to map values by key instead of index.

Dependencies:
  - Updated Microsoft.Extensions.Logging.Abstractions from 7.0.0 to 8.0.1 to match that of VRCFaceTracking.Core version 5.2.3.0.
  - Switched from System.Text.Json to Newtonsoft.Json because I encountered runtime import issues that I couldn't solve otherwise.
